### PR TITLE
Use transition event to check whether the animation has finished to fix visual problems caused by any performance problems.

### DIFF
--- a/src/javascripts/junior.js
+++ b/src/javascripts/junior.js
@@ -85,21 +85,20 @@ var Jr = Jr || {};
       var appContainer = $('#app-container');
       appContainer.prepend(toEl);
 
-      toEl.addClass('animate-to-view').addClass(direction).addClass('initial');
-      appContainer.addClass('animate');
-      appContainer.addClass(direction);
-
-      var next = function() {
+      toEl.addClass('animate-to-view initial ' + direction);
+      appContainer.addClass('animate ' + direction);
+      setTimeout(function () {
         return toEl.removeClass('initial');
-      };
-      var after = function() {
+      }, 1);
+
+      appContainer.bind('webkitTransitionEnd transitionend oTransitionEnd', function (event) {
         fromEl.remove();
         toEl.attr('id', 'app-main');
-        toEl.removeClass('animate-to-view').removeClass(direction);
-        return appContainer.removeClass('animate').removeClass(direction);
-      };
-      setTimeout(next, 1);
-      appContainer.bind('webkitTransitionEnd transitionend oTransitionEnd', after);
+        toEl.removeClass('animate-to-view ' + direction);
+        
+        $(this).unbind(event);
+        return appContainer.removeClass('animate ' + direction);
+      });
 
       return;
     }

--- a/src/javascripts/junior.js
+++ b/src/javascripts/junior.js
@@ -82,22 +82,26 @@ var Jr = Jr || {};
       }
     },
     doAnimation: function(fromEl, toEl, type, direction) {
-      var after, next;
-      $('#app-container').prepend(toEl);
+      var appContainer = $('#app-container');
+      appContainer.prepend(toEl);
+
       toEl.addClass('animate-to-view').addClass(direction).addClass('initial');
-      $('#app-container').addClass('animate');
-      $('#app-container').addClass(direction);
-      next = function() {
+      appContainer.addClass('animate');
+      appContainer.addClass(direction);
+
+      var next = function() {
         return toEl.removeClass('initial');
       };
-      setTimeout(next, 1);
-      after = function() {
+      var after = function() {
         fromEl.remove();
         toEl.attr('id', 'app-main');
         toEl.removeClass('animate-to-view').removeClass(direction);
-        return $('#app-container').removeClass('animate').removeClass(direction);
+        return appContainer.removeClass('animate').removeClass(direction);
       };
-      return setTimeout(after, 400);
+      setTimeout(next, 1);
+      appContainer.bind('webkitTransitionEnd transitionend oTransitionEnd', after);
+
+      return;
     }
   };
 

--- a/src/javascripts/junior.js
+++ b/src/javascripts/junior.js
@@ -106,7 +106,24 @@ var Jr = Jr || {};
 
   Jr.Router = Backbone.Router.extend({
     renderView: function(view) {
-      return Jr.Navigator.renderView($('#app-main'), view);
+      var appContainer = $('#app-container');
+      var isNotAnimating = function () {
+        return !appContainer.hasClass('animate');
+      };
+
+      var response;
+      if (isNotAnimating()) {
+          response = Jr.Navigator.renderView($('#app-main'), view);
+      } else {
+        var intervalId = setInterval(function () {
+          if (isNotAnimating()) {
+            clearInterval(intervalId);
+            response = Jr.Navigator.renderView($('#app-main'), view);
+          }   
+        }, 100)
+      }
+
+      return response;
     }
   })
 })(Jr);


### PR DESCRIPTION
Fixed performance problems on iOS6 causing a white block to appear where the initial view you were moving from is removed too early. Now we wait for the animation to officially end rather than make assumptions.
