### PR TITLE
View switch too quickly would overlap

### DIFF
--- a/src/javascripts/junior.js
+++ b/src/javascripts/junior.js
@@ -92,6 +92,10 @@ var Jr = Jr || {};
       };
       setTimeout(next, 1);
       after = function() {
+        for (var mainDivs = $('#app-container>div'), i = 0; i < mainDivs.length; i++) {
+            if (mainDivs.length > 1)
+                mainDivs.last().remove();
+        }
         fromEl.remove();
         toEl.attr('id', 'app-main');
         toEl.removeClass('animate-to-view').removeClass(direction);


### PR DESCRIPTION
View switch too quickly would overlap. My solution is that every time after the switch, determine how many views in "#app-container" layer, if there are many views, it removes the previous.